### PR TITLE
ci: update or add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/stale@v4
         with:
           days-before-stale: 30
-          days-before-close: 60
+          days-before-close: 30
           stale-pr-message: >
             This issue has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs.


### PR DESCRIPTION
#### Why
We want to reduce the default amount of time it takes to close
PRs that have been marked as 'stale', from 60 days to 30 days.

The stale workflow uses GitHub Actions to automatically mark PRs
as stale and eventually close them if there is no detected activity.
This workflow excludes any dependency or security PRs.

For more information about the stale GitHub Action see: https://github.com/actions/stale

#### What changed
* Add @wealthsimple/developer-tools as a CODEOWNER for all GitHub Actions workflows (if applicable)
* If this repo has an existing 'stale.yml' workflow, reduce the 'days-before-close' from 60 to 30 (if applicable)
* If this repo _does not_ have a 'stale.yml' workflow, add one!


:warning: This PR was opened automatically! Please reach out in #developer-tools on Slack if you have any questions!