### PR TITLE
fix: update pr template process link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-Please follow the [Pull Request Process](https://backstage.iad.w10e.com/docs/default/component/eng-handbook/practices-processes/pull-request-reviews/#pull-request-process) while creating your Pull Request. You can use the below template to help you structure your thoughts.
+Please follow the [Pull Request Process](https://www.notion.so/wealthsimple/Pull-Requests-and-Code-Reviews-b30b2fd48aa74f2e8b0b7433d446f561?pvs=4) while creating your Pull Request. You can use the below template to help you structure your thoughts.
 
 ### Why
 
@@ -8,15 +8,13 @@ Please follow the [Pull Request Process](https://backstage.iad.w10e.com/docs/def
 
 <!-- Replace with a short description what is being modified. At a high level, you let the reviewer know the overall effect of the PR. What approach did you take to solve the problem? What could go wrong? -->
 
-### How I tested
-
-* <!-- Bullets for test cases covered -->
-
-### Security 🛡 (required)
 #### Checklist
+
 <!-- Please review the checklist for any potential security risks/vulnerabilities  -->
 - [ ] Reviewed the [Checklist](https://docs.google.com/document/d/1wT4XI3eaXkb_fWTF4gyKP_0HFjjznA4AkEII0W-imKo/edit)
+
 #### How does this PR handle security?
+
 <!--
 What steps are you taking to ensure there are no vulnerabilities? Examples include:
 "My PR is not logging any sensitive info"
@@ -24,9 +22,9 @@ What steps are you taking to ensure there are no vulnerabilities? Examples inclu
 -->
 
 ### Screenshot
+
 <!-- If you can, provide a screenshot or a video of the changes as an image is worth a thousand words -->
 
 ### Next steps
 
 <!-- If your PR is part of a few or a WIP, give context to reviewers -->
-


### PR DESCRIPTION
The PR process link was pointing to the old backstage `eng-handbook` docs. Updated to point to Notion.
