### PR TITLE
chore: add jira ticket link to pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 Please follow the [Pull Request Process](https://www.notion.so/wealthsimple/Pull-Requests-and-Code-Reviews-b30b2fd48aa74f2e8b0b7433d446f561?pvs=4) while creating your Pull Request. You can use the below template to help you structure your thoughts.
 
 ### Jira Ticket
-<!-- If your PR addresses a Jira ticket, link it here -->
+<!-- Please include a link to an associated JIRA ticket. Hotfixes / Incidents do not require JIRA tickets, but most changes should be scoped and tracked. -->
 https://wealthsimple.atlassian.net/browse/JIRA-1234
 
 ### Why

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 Please follow the [Pull Request Process](https://www.notion.so/wealthsimple/Pull-Requests-and-Code-Reviews-b30b2fd48aa74f2e8b0b7433d446f561?pvs=4) while creating your Pull Request. You can use the below template to help you structure your thoughts.
 
+### Jira Ticket
+<!-- If your PR addresses a Jira ticket, link it here -->
+https://wealthsimple.atlassian.net/browse/JIRA-1234
+
 ### Why
 
 <!-- Replace with a short description of why is this change required. The “why” tells us what business or engineering goal this change achieves. The “why” is a chance to explain both the engineering goal and some business objective that is satisfied or moved along. This is also the record of the company's decision-making process, beneficial when looking back. -->


### PR DESCRIPTION
### Jira Ticket
https://wealthsimple.atlassian.net/browse/BEPLAT-1021

### Why
For compliance reasons, every PR should be linked to a Jira ticket. To encourage this behaviour, this PR adds a section to the pull request template to include a ticket.

### What is changing
* Added a Jira ticket section to `pull_request_template.md`

### Next steps
To further enforce Jira ticket inclusion in PRs, a GitHub workflow should be created in the future to issue a warning when a PR is created without a ticket link.
<!-- If your PR is part of a few or a WIP, give context to reviewers -->
